### PR TITLE
Add parseJsonSafely tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "rm -rf test-dist && tsc services/parseJsonSafely.ts --module es2022 --target es2020 --outDir test-dist/services && node --test tests/parseJsonSafely.test.js && rm -rf test-dist"
   },
   "dependencies": {
     "react-dom": "^19.1.0",

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -2,6 +2,7 @@
 import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
 import type { GlossaryEntry, Question, VideoSuggestion, GeminiMCQResponseItem, GeminiGlossaryResponseItem } from '../types';
 import { GEMINI_TEXT_MODEL, MAX_TOPICS } from '../constants'; // NUM_MCQS e NUM_SIMULADO_MCQS removidos
+import { parseJsonSafely } from './parseJsonSafely';
 
 // @ts-ignore Certifique-se que import.meta.env.VITE_GEMINI_API_KEY está disponível
 const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
@@ -11,25 +12,9 @@ if (!apiKey || apiKey === "COLE_AQUI_SUA_CHAVE_API_GEMINI_REAL") { // Modificado
 const ai = new GoogleGenAI({ apiKey: apiKey! });
 
 /**
- * Limpa e parseia uma string JSON, removendo possíveis cercas de markdown.
- * @param jsonString A string JSON, possivelmente com cercas de markdown.
- * @returns O objeto JSON parseado.
- * @throws Error se o parse falhar.
+ * @deprecated Mantenha este comentário para compatibilidade com versões anteriores.
+ * A função parseJsonSafely foi movida para './parseJsonSafely'.
  */
-const parseJsonSafely = <T,>(jsonString: string): T => {
-  let cleanJsonString = jsonString.trim();
-  const fenceRegex = /^```(?:json)?\s*\n?(.*?)\n?\s*```$/s;
-  const match = cleanJsonString.match(fenceRegex);
-  if (match && match[1]) {
-    cleanJsonString = match[1].trim();
-  }
-  try {
-    return JSON.parse(cleanJsonString) as T;
-  } catch (e) {
-    console.error("Falha ao parsear JSON:", e, "String original:", jsonString, "String limpa:", cleanJsonString);
-    throw new Error(`Formato de JSON inválido recebido da IA. Detalhes: ${(e as Error).message}`);
-  }
-};
 
 
 export async function generateSummary(text: string): Promise<string> {

--- a/services/parseJsonSafely.ts
+++ b/services/parseJsonSafely.ts
@@ -1,0 +1,20 @@
+/**
+ * Limpa e parseia uma string JSON, removendo possíveis cercas de markdown.
+ * @param jsonString A string JSON, possivelmente com cercas de markdown.
+ * @returns O objeto JSON parseado.
+ * @throws Error se o parse falhar.
+ */
+export const parseJsonSafely = <T,>(jsonString: string): T => {
+  let cleanJsonString = jsonString.trim();
+  const fenceRegex = /^```(?:json)?\s*\n?(.*?)\n?\s*```$/s;
+  const match = cleanJsonString.match(fenceRegex);
+  if (match && match[1]) {
+    cleanJsonString = match[1].trim();
+  }
+  try {
+    return JSON.parse(cleanJsonString) as T;
+  } catch (e) {
+    console.error("Falha ao parsear JSON:", e, "String original:", jsonString, "String limpa:", cleanJsonString);
+    throw new Error(`Formato de JSON inválido recebido da IA. Detalhes: ${(e as Error).message}`);
+  }
+};

--- a/tests/parseJsonSafely.test.js
+++ b/tests/parseJsonSafely.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { parseJsonSafely } from '../test-dist/services/parseJsonSafely.js';
+import { test } from 'node:test';
+
+test('removes markdown fences', () => {
+  const input = '```json\n{"a":1}\n```';
+  const result = parseJsonSafely(input);
+  assert.deepEqual(result, {a:1});
+});
+
+test('returns parsed object without fences', () => {
+  const input = '{"b":2}';
+  const result = parseJsonSafely(input);
+  assert.deepEqual(result, {b:2});
+});
+
+test('throws on invalid json', () => {
+  assert.throws(() => parseJsonSafely('invalid'), /Formato de JSON inválido/);
+});


### PR DESCRIPTION
## Summary
- expose `parseJsonSafely` as a utility
- update Gemini service to import the new helper
- add node-based tests for `parseJsonSafely`
- provide npm script to run the tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68420b89d8b4832a9b6378be0534ae40